### PR TITLE
TASK: Remove `property` from field in favor of consistent use of `name`

### DIFF
--- a/Classes/Eel/FormHelper.php
+++ b/Classes/Eel/FormHelper.php
@@ -74,24 +74,28 @@ class FormHelper implements ProtectedContextAwareInterface
      * Create a field definition object
      *
      * @param FormDefinition|null $form
-     * @param string $path
+     * @param string $name
      * @param bool $multiple
      * @return FieldDefinition
      */
-    public function createFieldDefinition(FormDefinition $form = null, string $path = null, bool $multiple = false): FieldDefinition
+    public function createFieldDefinition(FormDefinition $form = null, string $name = null, bool $multiple = false): FieldDefinition
     {
-        if (!$path) {
+        if (!$name) {
             return new FieldDefinition(null, null, null);
         }
+
         // render fieldName
         if ($form && $form->getFieldNamePrefix()) {
-            $fieldName = $this->pathToFieldName($form->getFieldNamePrefix() . '.' . $path);
+            $fieldName = $this->prefixFieldName($name, $form->getFieldNamePrefix());
         } else {
-            $fieldName = $this->pathToFieldName($path);
+            $fieldName = $name;
         }
         if ($multiple) {
             $fieldName .= '[]';
         }
+
+        // create property path from fieldname
+        $path = $this->fieldNameToPath($name);
 
         // determine value, according to the following algorithm:
         if ($form && $form->getResult() !== null && $form->getResult()->hasErrors()) {
@@ -325,9 +329,8 @@ class FormHelper implements ProtectedContextAwareInterface
      *
      * @param $name
      * @return string
-     * @TODO: decide wether this really has to be exposed as public method
      */
-    public function fieldNameToPath($name): string
+    protected function fieldNameToPath($name): string
     {
         $path = preg_replace('/(\]\[|\[|\])/', '.', $name);
         return trim($path, '.');

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Pure fusion form rendering with afx support!
     ```
     form = ${form} 
     name = null
-    property = ${Form.fieldNameToPath(this.name)}
     multiple = false
     ```
     
@@ -40,7 +39,6 @@ Pure fusion form rendering with afx support!
     ```
     form = ${form}  
     name = null
-    property = ${this.name ? Form.fieldNameToPath(this.name) : null}
     multiple = false
 
     label = null
@@ -51,7 +49,7 @@ Pure fusion form rendering with afx support!
 
 **Field Prototypes: based on Neos.Fusion.Form:FieldComponent**
 
-All field types allow to define `id`, `class` `name`, `property`, `value` and `attributes`. 
+All field types allow to define `form`, `name` and `multiple` from the FieldComponent.  
 
 - `Neos.Fusion.Form:Input`
 - `Neos.Fusion.Form:Hidden`

--- a/Resources/Private/Fusion/Prototypes/FieldComponent.fusion
+++ b/Resources/Private/Fusion/Prototypes/FieldComponent.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Fusion.Form:FieldComponent)  < prototype(Neos.Fusion:Component) {
-    @context.field = ${this.property ? Form.createFieldDefinition(this.form, this.property, this.multiple) : field}
+    @context.field = ${this.property ? Form.createFieldDefinition(this.form, this.name, this.multiple) : field}
 
     @propTypes {
         form = ${PropTypes.instanceOf('Neos\Fusion\Form\Domain\Model\FormDefinition')}
@@ -19,7 +19,6 @@ prototype(Neos.Fusion.Form:FieldComponent)  < prototype(Neos.Fusion:Component) {
     #
     form = ${form}
     name = null
-    property = ${this.name ? Form.fieldNameToPath(this.name) : null}
     multiple = false
 
     #

--- a/Resources/Private/Fusion/Prototypes/FieldContainer.fusion
+++ b/Resources/Private/Fusion/Prototypes/FieldContainer.fusion
@@ -1,5 +1,5 @@
 prototype(Neos.Fusion.Form:FieldContainer)  < prototype(Neos.Fusion:Component) {
-    @context.field = ${Form.createFieldDefinition(this.form, this.property, this.multiple)}
+    @context.field = ${Form.createFieldDefinition(this.form, this.name, this.multiple)}
 
     @propTypes {
         form = ${PropTypes.instanceOf('Neos\Fusion\Form\Domain\Model\FormDefinition')}
@@ -15,7 +15,6 @@ prototype(Neos.Fusion.Form:FieldContainer)  < prototype(Neos.Fusion:Component) {
 
     form = ${form}
     name = null
-    property = ${this.name ? Form.fieldNameToPath(this.name) : null}
     multiple = false
 
     id = null


### PR DESCRIPTION
Instead of using `name` and `property` as synonym options with slightly different syntax the `property` is removed and only the `name` option is left to define the fieldname in html-sytax with square  brackets for nested properties.

This straightens the interface of the form helper an allows to stop exposing fieldNameToPath to eel.