### PR TITLE
DOCS: Add documentation for extending Neos.Fusion.Form

### DIFF
--- a/Resources/Private/Fusion/Prototypes/FieldComponent.fusion
+++ b/Resources/Private/Fusion/Prototypes/FieldComponent.fusion
@@ -1,9 +1,6 @@
 prototype(Neos.Fusion.Form:FieldComponent)  < prototype(Neos.Fusion:Component) {
 
-    #
-    # populate field context to be available during prop evaluation
-    #
-    @context.field = ${Form.createField(form, this.name, this.multiple)}
+    @context.field = ${this.field}
 
     @propTypes {
         field = ${PropTypes.instanceOf('Neos\Fusion\Form\Domain\Model\Field')}
@@ -21,6 +18,7 @@ prototype(Neos.Fusion.Form:FieldComponent)  < prototype(Neos.Fusion:Component) {
     #
     name = null
     multiple = false
+    field = ${Form.createField(form, this.name, this.multiple)}
 
     #
     # generic attributes that all fields item components should support

--- a/Resources/Private/Fusion/Prototypes/Form.fusion
+++ b/Resources/Private/Fusion/Prototypes/Form.fusion
@@ -1,9 +1,6 @@
 prototype(Neos.Fusion.Form:Form) < prototype(Neos.Fusion:Component) {
 
-    #
-    # populate form context to be available during prop evaluation
-    #
-    @context.form = ${Form.createForm(request, this.fieldnamePrefix, this.data)}
+    @context.form = ${this.form}
 
     @propTypes {
         fieldnamePrefix = ${PropTypes.string}
@@ -23,6 +20,7 @@ prototype(Neos.Fusion.Form:Form) < prototype(Neos.Fusion:Component) {
     #
     fieldnamePrefix = null
     data = Neos.Fusion:DataStructure
+    form = ${Form.createForm(request, this.fieldnamePrefix, this.data)}
 
     #
     # html attributes for the form

--- a/Resources/Private/Fusion/Prototypes/Neos/BackendModule.FieldContainer.fusion
+++ b/Resources/Private/Fusion/Prototypes/Neos/BackendModule.FieldContainer.fusion
@@ -1,26 +1,14 @@
-prototype(Neos.Fusion.Form:Neos.BackendModule.FieldContainer)  < prototype(Neos.Fusion:Component) {
-    @context.field = ${Form.createField(form, this.name, this.multiple)}
+prototype(Neos.Fusion.Form:Neos.BackendModule.FieldContainer)  < prototype(Neos.Fusion.Form:FieldComponent) {
 
     @propTypes {
-        form = ${PropTypes.instanceOf('Neos\Fusion\Form\Domain\Model\Form')}
-        name = ${PropTypes.string}
-        multiple = ${PropTypes.boolean}
         label = ${PropTypes.string}
         content = ${PropTypes.string}
     }
 
     #
+    # label and afx content
     #
-    #
-    name = null
-    multiple = false
-
-    # label
     label = null
-
-    #
-    # afx content
-    #
     content = null
 
     #
@@ -60,12 +48,12 @@ prototype(Neos.Fusion.Form:Neos.BackendModule.FieldContainer)  < prototype(Neos.
     `
 
     #
-    # Fields that are rendered inside field container are adjusted
+    # FieldComponent that are rendered inside field container are adjusted
+    # if no specific name is given the field from the container is reused
+    # if nop specific id is given the name from the comntainer is used
     #
     prototype(Neos.Fusion.Form:FieldComponent) {
-        // if no specific name is given the field from the container is reused
-        @context.field = ${this.name ? Form.createField(form, this.name, this.multiple) : field}
-        // if specific id is given the name from the field is rendered as id
+        field = ${this.name ? Form.createField(form, this.name, this.multiple) : field}
         id = ${field.name}
     }
 }


### PR DESCRIPTION
In addition the handling of form and field context was adjusted for simplicity.
Also the `Neos.Fusion.Form:Neos.BackendModule.FieldContainer` is adjusted
to inherit from `Neos.Fusion.Form:FieldComponent`.