### PR TITLE
TASK: Use propertyMapper for value Stringification

### DIFF
--- a/Classes/Domain/AbstractFormObject.php
+++ b/Classes/Domain/AbstractFormObject.php
@@ -15,16 +15,15 @@ namespace Neos\Fusion\Form\Domain;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
-use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Property\PropertyMapper;
 
 abstract class AbstractFormObject implements ProtectedContextAwareInterface
 {
-
     /**
-     * @var PersistenceManagerInterface
      * @Flow\Inject
+     * @var PropertyMapper
      */
-    protected $persistenceManager;
+    protected $propertyMapper;
 
     /**
      * Convert a value to a string representation for beeing rendered as an html form value
@@ -34,13 +33,11 @@ abstract class AbstractFormObject implements ProtectedContextAwareInterface
      */
     protected function stringifyValue($value): string
     {
-        if (is_object($value)) {
-            $identifier = $this->persistenceManager->getIdentifierByObject($value);
-            if ($identifier !== null) {
-                return $identifier;
-            }
+        try {
+            return $this->propertyMapper->convert($value, 'string');
+        } catch (\Exception $e) {
+            return (string)$value;
         }
-        return (string)$value;
     }
 
     /**

--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -19,6 +19,7 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 
 /**
  * This object describes a the main properties of a form. Usually this is
@@ -34,6 +35,12 @@ class Form extends AbstractFormObject
      * @var MvcPropertyMappingConfigurationService
      */
     protected $mvcPropertyMappingConfigurationService;
+
+    /**
+     * @var PersistenceManagerInterface
+     * @Flow\Inject
+     */
+    protected $persistenceManager;
 
     /**
      * @Flow\Inject


### PR DESCRIPTION
The previous logic used the persistence identifiers for objects and casted all other values to string.

This change replaces by calling the propertyMapper->convert with target format 'string' which is configurable by the user. This makes sense as propertyMapping from string to object will be used in the targetController anyways.