### PR TITLE
SECURITY: Pass content for textarea field trough htmlspecialchars

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ prototypeVendor.Site:Form.Textarea)  < prototype(Neos.Fusion.Form:Component.Fiel
             name={field.name}
             {...props.attributes}
         >
-            {field.getCurrentValueStringified() || props.content)}
+            {String.htmlspecialchars(field.getCurrentValueStringified() || props.content)}
         </textarea>
     `
 }

--- a/Resources/Private/Fusion/Prototypes/Textarea.fusion
+++ b/Resources/Private/Fusion/Prototypes/Textarea.fusion
@@ -5,7 +5,7 @@ prototype(Neos.Fusion.Form:Textarea)  < prototype(Neos.Fusion.Form:Component.Fie
             name={field.getName()}
             {...props.attributes}
         >
-            {field.getCurrentValueStringified() || props.content}
+            {String.htmlspecialchars(field.getCurrentValueStringified() || props.content)}
         </textarea>
     `
 }


### PR DESCRIPTION
Without this change malicious content submitted for a textarea field will be
rerendered without checks again and can insert code to the website.

The other fieldtypes are not affected as those render the values as attributes which get htmlspecialchars applied automatically.