### PR TITLE
TASK: Allow newer PHPUnit versions (7.1.x, 8.x, 9.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "neos/utility-objecthandling": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1"
+        "phpunit/phpunit": "^7.1 || ^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See https://github.com/neos/neos-development-collection/issues/3227