### PR TITLE
TASK: Use github actions instead of TravisCi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+      branches:
+        - 'master'
+  pull_request: ~
 
 jobs:
     test:
@@ -10,6 +14,12 @@ jobs:
             fail-fast: false
             matrix:
                 php-versions: ['7.3', '7.4']
+                flow-versions: ['5.3', '6.3', '7.0']
+                include:
+                    - flow-versions: '5.3'
+                      php-versions: '7.1'
+                    - flow-versions: '5.3'
+                      php-versions: '7.2'
 
         runs-on: ubuntu-latest
 
@@ -26,8 +36,8 @@ jobs:
                   extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
                   ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
-            - name: Install dependencies
-              run: composer install --no-progress --no-interaction
+            - name: Set Flow Version
+              run: composer require neos/flow ^${{ matrix.flow-versions }} --no-progress --no-interaction
 
             - name: Run Tests
               run: composer test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        name: "Test"
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-versions: ['7.3', '7.4']
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  path: ${{ env.FLOW_FOLDER }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
+                  ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
+
+            - name: Install dependencies
+              run: composer install --no-progress --no-interaction
+
+            - name: Run Tests
+              run: composer test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     test:
-        name: "Test"
+        name: "Test (PHP ${{ matrix.php-versions }}, Flow ${{ matrix.flow-versions }})"
 
         strategy:
             fail-fast: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: php
-php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
-script: composer test


### PR DESCRIPTION
Travis was disabled a while ago, this restores the unit tests via github actions.