### PR TITLE
BUGFIX: Render collection items with implicit nodetype that have meta attributes correctly

### DIFF
--- a/Classes/Runtime/FusionObjects/AbstractCollectionFusionObject.php
+++ b/Classes/Runtime/FusionObjects/AbstractCollectionFusionObject.php
@@ -127,6 +127,6 @@ abstract class AbstractCollectionFusionObject extends AbstractArrayFusionObject
         if (!is_array($property)) {
             return false;
         }
-        return array_intersect_key(array_flip(Parser::$reservedParseTreeKeys), $property) === [];
+        return !isset($property['__objectType']) && !isset($property['__eelExpression']);
     }
 }


### PR DESCRIPTION
The arrayCollection detected untyped properties by checking that no reserved fusion path was set.
This caused otherwise untyped properties that had @if or @process to not be interpreted with the selected
itemPrototype.