### PR TITLE
BUGFIX: Render bound data when submitted values are null

### DIFF
--- a/Classes/Domain/Field.php
+++ b/Classes/Domain/Field.php
@@ -100,14 +100,16 @@ class Field extends AbstractFormObject
     protected function findCurrentValueByPath(string $path)
     {
         // determine value, according to the following algorithm:
-        if ($this->form && $this->form->getResult() !== null && $this->form->getResult()->hasErrors()) {
-            // 1) if a validation error has occurred, pull the value from the submitted form values.
-            $fieldValue = ObjectAccess::getPropertyPath($this->form->getSubmittedValues(), $path);
-        } elseif ($path && $this->form && $this->form->getData()) {
-            // 2) else, if "property" is specified, take the value from the bound object.
-            $fieldValue = ObjectAccess::getPropertyPath($this->form->getData(), $path);
-        } else {
-            $fieldValue = null;
+        $fieldValue = null;
+        if ($path && $this->form) {
+            if ($this->form->getResult() !== null && $this->form->getResult()->hasErrors()) {
+                // 1) if a validation error has occurred, pull the value from the submitted form values.
+                $fieldValue = ObjectAccess::getPropertyPath($this->form->getSubmittedValues(), $path);
+            }
+            if (is_null($fieldValue) && $this->form->getData()) {
+                // 2) else, if "property" is specified, take the value from the bound object.
+                $fieldValue = ObjectAccess::getPropertyPath($this->form->getData(), $path);
+            }
         }
         return $fieldValue;
     }


### PR DESCRIPTION
When validation errors were present the field value only tries to access the submitted values.
This caused confusion when bound data had a value for the path but the submitted values did not.

The change adds a fallback from submitted values to bound data in case the submitted data is null.

Resolves: #48