### PR TITLE
BUGFIX: validation error rendering

### DIFF
--- a/Resources/Private/Fusion/Prototypes/ErrorRenderer.fusion
+++ b/Resources/Private/Fusion/Prototypes/ErrorRenderer.fusion
@@ -11,8 +11,8 @@ prototype(Neos.Fusion.Form:ErrorRenderer)  < prototype(Neos.Fusion:Component) {
         <ul @if.hasResult={props.result} class={props.class}>
             <Neos.Fusion:Loop items={props.result.flattenedErrors} itemName="errors">
                 <Neos.Fusion:Loop items={errors} itemName="error">
-                    <li>{I18n.id(error.code).package(props.translationPackage).source(props.translationSource).value(error).translate()}</li>
-´               </Neos.Fusion:Loop>
+                    <li>{I18n.id(error.code).package(props.translationPackage).source(props.translationSource).value(error).arguments(error.arguments).translate()}</li>
+                </Neos.Fusion:Loop>
             </Neos.Fusion:Loop>
         </ul>
     `


### PR DESCRIPTION
### Example
```
prototype(Test.Test:Content.ContactForm) < prototype(Neos.Neos:ContentComponent) {
    renderer = Neos.Fusion.Form:Runtime.RuntimeForm {
        process = Neos.Fusion.Form:Runtime.SingleStepProcess {
            schema {
                name = ${Form.Schema.string().isRequired().validator('StringLength', {minimum: 3, maximum: 100})}
            }

            content = afx`
                <Neos.Fusion.Form:FieldContainer field.name="name" label="NAME">
                    <Neos.Fusion.Form:Input errorClass="is-invalid" attributes.class="form-control" attributes.id="name" attributes.required="required"/>
                </Neos.Fusion.Form:FieldContainer>
            `
        }
    }
}
```

### Result
When validation fails, arguments are not applied to translation message:
`Die Länge des Textes muss zwischen {0,number} und {1,number} Zeichen liegen`

### Expected
`Die Länge des Textes muss zwischen 3 und 100 Zeichen liegen`