### PR TITLE
BUGFIX: Relax version constraint for guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "neos/fusion-afx": "^1.2 || ^7.0 || dev-master",
         "neos/utility-arrays": "*",
         "neos/utility-objecthandling": "*",
-        "guzzlehttp/psr7": "^1.4 || ~2.0"
+        "guzzlehttp/psr7": "*"
     },
     "require-dev": {
         "neos/swiftmailer": "*",


### PR DESCRIPTION
## The Problem

I'm currently investigating failing E2E tests in the Neos UI repository. While I could fix the problem for the `master` branch, there's still trouble remaining for `7.0`.

In PR https://github.com/neos/neos-ui/pull/2922 I found out, that the problem is due to a deprecated Guzzle function used here:
https://github.com/neos/flow-development-collection/blob/7.0/Neos.Flow/Classes/Mvc/ActionResponse.php#L6

And a broken version Constraint in Neos.Http.Factories 7.0.7:
https://github.com/neos/flow-development-collection/blob/7.0.7/Neos.Http.Factories/composer.json#L12

Which is actually fixed in 7.0.8:
https://github.com/neos/flow-development-collection/blob/7.0.8/Neos.Http.Factories/composer.json#L12

Nevertheless, composer consistently installs Neos.Http.Factories 7.0.7 instead of 7.0.8. 

This is very likely due to the version constraint in Neos.Fusion.Form, as can be seen here:
```
$ composer why guzzlehttp/psr7
guzzlehttp/guzzle    7.3.0   requires  guzzlehttp/psr7 (^1.7 || ^2.0)           
neos/fusion-form     v2.0.2  requires  guzzlehttp/psr7 (^1.4 || ~2.0)           
neos/http-factories  7.0.7   requires  guzzlehttp/psr7 (^1.4, !=1.8.0 || ~2.0)
```

Apparently, composer prefers `guzzlehttp/psr7:~2.0` due to the constraint in `neos/fusion-form`. That pushes `neos/http-factories` back to `7.0.7`, which has a compatible constraint.

## Possible solution

Neos.Fusion.Form has an implicit dependency to guzzlehttp/psr7 through Neos.Flow -> Neos.Http.Factories.

In order not to accidentally override version constraints set by Neos.Flow or Neos.Http.Factories, Neos.Fusion.Form should rely on whatever version of guzzlehttp/psr7 Flow brought with.

Accordingly, this PR sets the version constraint fpr `guzzlehttp/psr7` to `*`.