### PR TITLE
BUGFIX: props.class ignored in FieldContainer

### DIFF
--- a/Resources/Private/Fusion/Prototypes/FieldContainer.fusion
+++ b/Resources/Private/Fusion/Prototypes/FieldContainer.fusion
@@ -28,7 +28,7 @@ prototype(Neos.Fusion.Form:FieldContainer)  < prototype(Neos.Fusion.Form:Compone
     errorRenderer = 'Neos.Fusion.Form:ErrorRenderer'
 
     renderer = afx`
-        <div class={props.class + field.hasErrors() ? ' ' + props.errorClass : ''} {...props.attributes} >
+        <div class={props.class + (field.hasErrors() ? ' ' + props.errorClass : '')} {...props.attributes} >
             <Neos.Fusion:Renderer @if.hasErrors={props.label} type={props.labelRenderer} element.for={field.getName()} element.label={props.label} />
             {props.content}
             <Neos.Fusion:Renderer @if.hasErrors={field.hasErrors()} type={props.errorRenderer} element.result={field.getResult()} />


### PR DESCRIPTION
Without braces the props.class is ignored and props.error is always rendered.