### PR TITLE
Fix issue where filled form submit when you click on "previous step"

### DIFF
--- a/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
+++ b/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
@@ -107,7 +107,7 @@ class MultiStepProcessImplementation extends AbstractFusionObject implements Pro
         if ($this->targetSubProcessKey) {
             $request->setArgument('__submittedArguments', []);
             $request->setArgument('__submittedArgumentValidationResults', new Result());
-        } elseif ($currentSubProcess->isFinished() ) {
+        } elseif ($currentSubProcess->isFinished()) {
             if (!$this->state) {
                 $this->state = new FormState();
             }


### PR DESCRIPTION
When you use a multi step runtime form you can't go a step back when the form is filled.

I switched the if/else statement so that it check for a target before submitting.

You can use the [MultiStepForm Example](https://github.com/neos/fusion-form/blob/master/Documentation/Examples/MultiStepForm.md) to test it.