### PR TITLE
BUGFIX: Allow back navigation on confirmation step.

### DIFF
--- a/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
+++ b/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
@@ -130,6 +130,10 @@ class MultiStepProcessImplementation extends AbstractFusionObject implements Pro
             return false;
         }
 
+        if ($this->targetSubProcessKey) {
+            return false;
+        }
+
         $subProcesses = $this->getSubProcesses();
 
         foreach ($subProcesses as $subProcessKey => $subProcess) {


### PR DESCRIPTION
A Multistep process is considered to be finished once all steps are committed. This causes problems on the confirmation step as this adds no data and thus is always considered valid once submitted. Because of that the process was finished even after the user navigated back on the confirmation step.

The definition of isFinished for the MultiStepProcess is adjusted to "allSteps are committed and no target is set"

This change alters the multiStepProcess to only declare itself finished if no target step is set.