### PR TITLE
FEATURE: Add `enableReferrer` and `enableTrustedProperties` to the Form Definition

### DIFF
--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -67,6 +67,16 @@ class Form extends AbstractFormObject
     protected $encoding;
 
     /**
+     * @var bool
+     */
+    protected $disableReferrer;
+
+    /**
+     * @var bool
+     */
+    protected $disableTrustedProperties;
+
+    /**
      * @var string|null
      */
     protected $namespace;
@@ -89,8 +99,10 @@ class Form extends AbstractFormObject
      * @param string|null $target
      * @param string|null $method
      * @param string|null $encoding
+     * @param bool $disableReferrer
+     * @param bool $disableTrustedProperties
      */
-    public function __construct(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null)
+    public function __construct(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $disableReferrer = false, bool $disableTrustedProperties = false)
     {
         $this->request = $request;
         $this->data = $data;
@@ -98,6 +110,8 @@ class Form extends AbstractFormObject
         $this->target = $target;
         $this->method = $method;
         $this->encoding = $encoding;
+        $this->disableReferrer = $disableReferrer;
+        $this->disableTrustedProperties = $disableTrustedProperties;
 
         // determine submitted values and result from request
         /** @phpstan-ignore-next-line the return type of $request->getInternalArgument is misleading */
@@ -245,7 +259,7 @@ class Form extends AbstractFormObject
         // forwarded to the previous request where the __submittedArguments and
         // __submittedArgumentValidationResults can be handled from Form.createField or custom logic.
         //
-        if ($request) {
+        if ($request && ($this->disableReferrer !== true)) {
             $childRequestArgumentNamespace = null;
             while ($request instanceof ActionRequest) {
                 $requestArgumentNamespace = $request->getArgumentNamespace();
@@ -335,7 +349,8 @@ class Form extends AbstractFormObject
             foreach ($formFieldNames as $name) {
                 $path = $this->fieldNameToPath(substr($name, strlen($fieldNamePrefix)));
                 $pathSegments = explode('.', $path);
-                for ($i = 1; $i < count($pathSegments); $i++) {
+                $pathSegmentCount = count($pathSegments);
+                for ($i = 1; $i < $pathSegmentCount; $i++) {
                     $possiblePathes[] = implode('.', array_slice($pathSegments, 0, $i));
                 }
             }
@@ -357,7 +372,9 @@ class Form extends AbstractFormObject
         // A signed array of all properties the property mapper is allowed to convert from string to the target type
         // so no property mapping configuration is needed on the target controller
         //
-        $hiddenFields[ $this->prefixFieldName('__trustedProperties', $fieldNamePrefix) ] = $this->mvcPropertyMappingConfigurationService->generateTrustedPropertiesToken($formFieldNames, $fieldNamePrefix);
+        if ($this->disableTrustedProperties !== true) {
+            $hiddenFields[$this->prefixFieldName('__trustedProperties', $fieldNamePrefix)] = $this->mvcPropertyMappingConfigurationService->generateTrustedPropertiesToken($formFieldNames, $fieldNamePrefix);
+        }
 
         return $hiddenFields;
     }

--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -69,12 +69,12 @@ class Form extends AbstractFormObject
     /**
      * @var bool
      */
-    protected $disableReferrer;
+    protected $enableReferrer;
 
     /**
      * @var bool
      */
-    protected $disableTrustedProperties;
+    protected $enableTrustedProperties;
 
     /**
      * @var string|null
@@ -99,10 +99,10 @@ class Form extends AbstractFormObject
      * @param string|null $target
      * @param string|null $method
      * @param string|null $encoding
-     * @param bool $disableReferrer
-     * @param bool $disableTrustedProperties
+     * @param bool $enableReferrer
+     * @param bool $enableTrustedProperties
      */
-    public function __construct(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $disableReferrer = false, bool $disableTrustedProperties = false)
+    public function __construct(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $enableReferrer = true, bool $enableTrustedProperties = true)
     {
         $this->request = $request;
         $this->data = $data;
@@ -110,8 +110,8 @@ class Form extends AbstractFormObject
         $this->target = $target;
         $this->method = $method;
         $this->encoding = $encoding;
-        $this->disableReferrer = $disableReferrer;
-        $this->disableTrustedProperties = $disableTrustedProperties;
+        $this->enableReferrer = $enableReferrer;
+        $this->enableTrustedProperties = $enableTrustedProperties;
 
         // determine submitted values and result from request
         /** @phpstan-ignore-next-line the return type of $request->getInternalArgument is misleading */
@@ -259,7 +259,7 @@ class Form extends AbstractFormObject
         // forwarded to the previous request where the __submittedArguments and
         // __submittedArgumentValidationResults can be handled from Form.createField or custom logic.
         //
-        if ($request && ($this->disableReferrer !== true)) {
+        if ($request && ($this->enableReferrer === true)) {
             $childRequestArgumentNamespace = null;
             while ($request instanceof ActionRequest) {
                 $requestArgumentNamespace = $request->getArgumentNamespace();
@@ -372,7 +372,7 @@ class Form extends AbstractFormObject
         // A signed array of all properties the property mapper is allowed to convert from string to the target type
         // so no property mapping configuration is needed on the target controller
         //
-        if ($this->disableTrustedProperties !== true) {
+        if ($this->enableTrustedProperties === true) {
             $hiddenFields[$this->prefixFieldName('__trustedProperties', $fieldNamePrefix)] = $this->mvcPropertyMappingConfigurationService->generateTrustedPropertiesToken($formFieldNames, $fieldNamePrefix);
         }
 

--- a/Classes/FusionObjects/FormDefinitionImplementation.php
+++ b/Classes/FusionObjects/FormDefinitionImplementation.php
@@ -67,6 +67,23 @@ class FormDefinitionImplementation extends AbstractFusionObject
     {
         return $this->fusionValue('encoding');
     }
+
+    /**
+     * @return bool
+     */
+    protected function getDisableReferrer(): bool
+    {
+        return (bool)$this->fusionValue('disableReferrer');
+    }
+
+    /**
+     * @return bool
+     */
+    protected function getDisableTrustedProperties(): bool
+    {
+        return (bool)$this->fusionValue('disableTrustedProperties');
+    }
+
     /**
      * @return Form
      */
@@ -78,6 +95,8 @@ class FormDefinitionImplementation extends AbstractFusionObject
         $target = $this->getTarget();
         $method = $this->getMethod();
         $encoding = $this->getEncoding();
+        $disableReferrer = $this->getDisableReferrer();
+        $disableTrustedProperties = $this->getDisableTrustedProperties();
 
         return new Form(
             $request,
@@ -85,7 +104,9 @@ class FormDefinitionImplementation extends AbstractFusionObject
             $namespace,
             $target,
             $method,
-            $encoding
+            $encoding,
+            $disableReferrer,
+            $disableTrustedProperties
         );
     }
 }

--- a/Classes/FusionObjects/FormDefinitionImplementation.php
+++ b/Classes/FusionObjects/FormDefinitionImplementation.php
@@ -71,17 +71,17 @@ class FormDefinitionImplementation extends AbstractFusionObject
     /**
      * @return bool
      */
-    protected function getDisableReferrer(): bool
+    protected function getEnableReferrer(): bool
     {
-        return (bool)$this->fusionValue('disableReferrer');
+        return (bool)$this->fusionValue('enableReferrer');
     }
 
     /**
      * @return bool
      */
-    protected function getDisableTrustedProperties(): bool
+    protected function getEnableTrustedProperties(): bool
     {
-        return (bool)$this->fusionValue('disableTrustedProperties');
+        return (bool)$this->fusionValue('enableTrustedProperties');
     }
 
     /**
@@ -95,8 +95,8 @@ class FormDefinitionImplementation extends AbstractFusionObject
         $target = $this->getTarget();
         $method = $this->getMethod();
         $encoding = $this->getEncoding();
-        $disableReferrer = $this->getDisableReferrer();
-        $disableTrustedProperties = $this->getDisableTrustedProperties();
+        $enableReferrer = $this->getEnableReferrer();
+        $enableTrustedProperties = $this->getEnableTrustedProperties();
 
         return new Form(
             $request,
@@ -105,8 +105,8 @@ class FormDefinitionImplementation extends AbstractFusionObject
             $target,
             $method,
             $encoding,
-            $disableReferrer,
-            $disableTrustedProperties
+            $enableReferrer,
+            $enableTrustedProperties
         );
     }
 }

--- a/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
+++ b/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
@@ -132,13 +132,17 @@ class RuntimeFormImplementation extends AbstractFusionObject
     protected function renderForm(ProcessInterface $process, ActionRequest $formRequest, array $attributes)
     {
         $data = $process->getData();
+
+        // @todo adjust after raising min php version to 8+
+        // new Form(request:$formRequest, data: $data, method: 'post', encoding:'multipart/form-data', disableReferrer: true);
         $form = new Form(
             $formRequest,
             $data,
             null,
             null,
             'post',
-            'multipart/form-data'
+            'multipart/form-data',
+            true
         );
 
         $context = $this->runtime->getCurrentContext();

--- a/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
+++ b/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
@@ -134,7 +134,7 @@ class RuntimeFormImplementation extends AbstractFusionObject
         $data = $process->getData();
 
         // @todo adjust after raising min php version to 8+
-        // new Form(request:$formRequest, data: $data, method: 'post', encoding:'multipart/form-data', disableReferrer: true);
+        // new Form(request:$formRequest, data: $data, method: 'post', encoding:'multipart/form-data', enableReferrer: false);
         $form = new Form(
             $formRequest,
             $data,
@@ -142,6 +142,7 @@ class RuntimeFormImplementation extends AbstractFusionObject
             null,
             'post',
             'multipart/form-data',
+            false,
             true
         );
 

--- a/Documentation/FusionReference.rst
+++ b/Documentation/FusionReference.rst
@@ -24,6 +24,8 @@ In addition the form component will also:
 :form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.:attributes: (string), all props are rendered as attributes to the form tag
+:form.disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
+:form.disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
 :attributes: (`Neos.Fusion:DataStructure`_) form attributes, will override all automatically rendered ones
 :content: (string, defaults to '') afx content with the form controls
 
@@ -281,6 +283,8 @@ The Form component is a base prototype for rendering forms in afx. The prototype
 :form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
+:form.disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
+:form.disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
 :attributes: (`Neos.Fusion:DataStructure`_) form attributes, will override all automatically rendered ones
 :content: (string) form content, supported where needed
 
@@ -330,6 +334,8 @@ by the `Neos.Fusion.Form:Component.Form`_ prototype.
 :target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :method:  (string, default to `post`) The form method.
 :encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
+:disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
+:disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
 
 Neos.Fusion.Form:Definition.Field
 ---------------------------------

--- a/Documentation/FusionReference.rst
+++ b/Documentation/FusionReference.rst
@@ -24,8 +24,8 @@ In addition the form component will also:
 :form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.:attributes: (string), all props are rendered as attributes to the form tag
-:form.disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
-:form.disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
+:form.enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
+:form.enableTrustedProperties: (bool, defaults to true) Enable the generation of hidden `__trustedProperties` fields. Can be disabled when flow property mapping is not in use
 :attributes: (`Neos.Fusion:DataStructure`_) form attributes, will override all automatically rendered ones
 :content: (string, defaults to '') afx content with the form controls
 
@@ -283,8 +283,8 @@ The Form component is a base prototype for rendering forms in afx. The prototype
 :form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
-:form.disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
-:form.disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
+:form.enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
+:form.enableTrustedProperties: (bool, defaults to true) Enable the generation of hidden `__trustedProperties` fields. Can be disabled when flow property mapping is not in use
 :attributes: (`Neos.Fusion:DataStructure`_) form attributes, will override all automatically rendered ones
 :content: (string) form content, supported where needed
 
@@ -334,8 +334,8 @@ by the `Neos.Fusion.Form:Component.Form`_ prototype.
 :target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
 :method:  (string, default to `post`) The form method.
 :encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
-:disableReferrer: (bool, defaults to false) Disable generation of hidden `__referrer` fields. Can be used when the `method` is `get` or no flow validation is used
-:disableTrustedProperties: (bool, defaults to false) Disable generation of hidden `__trustedProperties` fields. Can be used when flow property mapping is not in use
+:enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
+:enableTrustedProperties: (bool, defaults to true) Enable the generation of hidden `__trustedProperties` fields. Can be disabled when flow property mapping is not in use
 
 Neos.Fusion.Form:Definition.Field
 ---------------------------------

--- a/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
+++ b/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
@@ -9,6 +9,8 @@ prototype(Neos.Fusion.Form:Definition.Form) {
         target = ${PropTypes.string}
         method = ${PropTypes.string}
         encoding = ${PropTypes.string}
+        disableReferrer = ${PropTypes.boolean}
+        disableTrustedProperties = ${PropTypes.boolean}
     }
 
     request = ${request}
@@ -17,4 +19,6 @@ prototype(Neos.Fusion.Form:Definition.Form) {
     target = Neos.Fusion:UriBuilder
     method = 'post'
     encoding = ${(String.toLowerCase(this.method) == 'post') ? 'multipart/form-data' : null}
+    disableReferrer = false
+    disableTrustedProperties = false
 }

--- a/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
+++ b/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
@@ -9,8 +9,8 @@ prototype(Neos.Fusion.Form:Definition.Form) {
         target = ${PropTypes.string}
         method = ${PropTypes.string}
         encoding = ${PropTypes.string}
-        disableReferrer = ${PropTypes.boolean}
-        disableTrustedProperties = ${PropTypes.boolean}
+        enableReferrer = ${PropTypes.boolean}
+        enableTrustedProperties = ${PropTypes.boolean}
     }
 
     request = ${request}
@@ -19,6 +19,6 @@ prototype(Neos.Fusion.Form:Definition.Form) {
     target = Neos.Fusion:UriBuilder
     method = 'post'
     encoding = ${(String.toLowerCase(this.method) == 'post') ? 'multipart/form-data' : null}
-    disableReferrer = false
-    disableTrustedProperties = false
+    enableReferrer = true
+    enableTrustedProperties = true
 }

--- a/Tests/Functional/FormTest.php
+++ b/Tests/Functional/FormTest.php
@@ -26,7 +26,7 @@ class FormTest extends TestCase
     /**
      * @return Form
      */
-    protected function createForm(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $disableReferrer = false, bool $disableTrustedProperties = false): Form
+    protected function createForm(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $enableReferrer = true, bool $enableTrustedProperties = true): Form
     {
         $reflector = new \ReflectionClass(Form::class);
         $form = $reflector->newInstanceArgs(func_get_args());
@@ -87,7 +87,7 @@ class FormTest extends TestCase
     public function calculateHiddenFieldsWillSkipTrustedPropertiesTokenIfDisabled()
     {
         // @todo once php 8 is min version adjust to `$this->createForm(disableTrustedProperties: true);`
-        $form = $this->createForm(null, null, null, null, null, null, false, true);
+        $form = $this->createForm(null, null, null, null, null, null, true, false);
         $this->mvcPropertyMappingConfigurationService->expects($this->never())->method('generateTrustedPropertiesToken');
 
         $hiddenFields = $form->calculateHiddenFields(null);
@@ -263,7 +263,7 @@ CONTENT;
         $request->method('getArgumentNamespace')->willReturn('');
 
         // @todo adjust to $this->createForm(request: $request, disableReferrer: true); once php 8 is min version
-        $form = $this->createForm($request, null, null, null, null, null, true);
+        $form = $this->createForm($request, null, null, null, null, null, false);
 
         $hiddenFields = $form->calculateHiddenFields(null);
 
@@ -295,7 +295,7 @@ CONTENT;
         $request->method('isMainRequest')->willReturn(false);
         $request->method('getParentRequest')->willReturn($parentRequest);
 
-        $form = $this->createForm($request, null, null, null, null, null, true);
+        $form = $this->createForm($request, null, null, null, null, null, false);
 
         $hiddenFields = $form->calculateHiddenFields(null);
 
@@ -436,7 +436,7 @@ CONTENT;
             ->willReturn('--argumentsWithHmac--');
 
         // @todo adjust to $this->createForm(request: $request, disableReferrer: true); once php 8 is min version
-        $form = $this->createForm($request, null, null, null, null, null, true);
+        $form = $this->createForm($request, null, null, null, null, null, false);
         $hiddenFields = $form->calculateHiddenFields(null);
 
         $this->assertArrayNotHasKey('__referrer[arguments]', $hiddenFields);


### PR DESCRIPTION
FEATURE: Add `enableReferrer ` and `enableTrustedProperties` to the prototype `Neos.Fusion.Form:Definition.Form` 
Both settings are disabled by default which does not change the current behavior.

- `enableReferrer`: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
- `enableTrustedProperties`: (bool, defaults to true) Enable the generation of hidden `__trustedProperties` fields. Can be disabled when flow property mapping is not in use

In Addition the RuntimeForm now sets `enableReferrer` to `false` because the runtime form only uses trusted properties but will never redirect back to the referrer.

Resolves: #73 