### PR TITLE
FEATURE: Add query arguments from form target uri to hidden fields if method == `get`

### DIFF
--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -217,7 +217,28 @@ class Form extends AbstractFormObject
         $xpath = new \DOMXPath($domDocument);
 
         //
-        // 1. Request Referrer parameters
+        // 1. Query arguments for the target url
+        //
+        // Render hidden form fields for query parameters from action URI.
+        // This is only needed if the form method is GET.
+        //
+        $target = $this->getTarget();
+        $method = $this->getMethod();
+        if ($target && $method && strtolower($method) === 'get') {
+            $query = parse_url($target, PHP_URL_QUERY);
+            if (is_string($query)) {
+                $queryParts = explode('&', $query);
+                foreach ($queryParts as $queryPart) {
+                    if (strpos($queryPart, '=') !== false) {
+                        list($parameterName, $parameterValue) = explode('=', $queryPart, 2);
+                        $hiddenFields[urldecode($parameterName)] = urldecode($parameterValue);
+                    }
+                }
+            }
+        }
+
+        //
+        // 2. Request Referrer parameters
         //
         // The referrer parameters allow flow framework to send the user back to the previous request
         // if the validation of submitted data was not successfull. In such a case the request will be
@@ -249,7 +270,7 @@ class Form extends AbstractFormObject
         }
 
         //
-        // 2. Empty hidden values for checkbox and multi-select values
+        // 3. Empty hidden values for checkbox and multi-select values
         //
         // those empty values allow to unset previously set properties since browsers would not
         // send a value for an unchecked checkbox or a select without any value
@@ -305,7 +326,7 @@ class Form extends AbstractFormObject
         }
 
         //
-        // 3. Hidden identity fields
+        // 4. Hidden identity fields
         //
         // When properties of persisted objects are modified the object __identity has to stored as an additional field
         //
@@ -331,7 +352,7 @@ class Form extends AbstractFormObject
         }
 
         //
-        // 4. Trusted properties token
+        // 5. Trusted properties token
         //
         // A signed array of all properties the property mapper is allowed to convert from string to the target type
         // so no property mapping configuration is needed on the target controller

--- a/Tests/Functional/FormTest.php
+++ b/Tests/Functional/FormTest.php
@@ -139,10 +139,10 @@ CONTENT;
             <select name="prefix[foo][]" multiple>
                 <optgroup label="foo">
                     <option>foo</option>
-                    <option>bar</option>                
+                    <option>bar</option>
                 </optgroup>
-                <option>baz</option>                
-                <option>bam</option>                
+                <option>baz</option>
+                <option>bam</option>
             </select>
 CONTENT;
 
@@ -168,10 +168,10 @@ CONTENT;
             <select name="prefix[foo]">
                 <optgroup label="foo">
                     <option>foo</option>
-                    <option>bar</option>                
+                    <option>bar</option>
                 </optgroup>
-                <option>baz</option>                
-                <option>bam</option>                
+                <option>baz</option>
+                <option>bam</option>
             </select>
 CONTENT;
 
@@ -328,7 +328,7 @@ CONTENT;
             <select name="select[multiple][]" multiple></select>
             <input name="input[checkbox]" type="checkbox" value="foo" />
             <input name="input[checkbox]" type="checkbox" value="bar" />
-            <input name="input[checkbox]" type="checkbox" value="baz" />   
+            <input name="input[checkbox]" type="checkbox" value="baz" />
             <input name="input[checkboxMultiple][]" type="checkbox" value="foo" />
             <input name="input[checkboxMultiple][]" type="checkbox" value="bar" />
             <input name="input[checkboxMultiple][]" type="checkbox" value="baz" />
@@ -349,10 +349,10 @@ CONTENT;
     {
         $content = <<<CONTENT
             <select name="select[single]"></select>
-            <input name="input[text]" type="text" />            
+            <input name="input[text]" type="text" />
             <input name="input[radio]" type="radio" value="foo" />
             <input name="input[radio]" type="radio" value="bar" />
-            <input name="input[radio]" type="radio" value="baz" /> 
+            <input name="input[radio]" type="radio" value="baz" />
 CONTENT;
 
         $form = $this->createForm();
@@ -457,5 +457,33 @@ CONTENT;
 
         $this->assertArrayNotHasKey('item1[__identity]', $hiddenFields);
         $this->assertArrayNotHasKey('item2[__identity]', $hiddenFields);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateHiddenFieldsAddsQueryArgumentsForMethodGet()
+    {
+        $form = $this->createForm(null, null, null, 'example.com?argument1=Example+%F0%9F%A6%86&nested[argument2]=%3A%2F%3F%23%5B%5D%40%20&nested[argument3]=%21%24%26%27%22%28%29%2A%2B%2C%3B%3D', 'get');
+
+        $hiddenFields = $form->calculateHiddenFields(null);
+
+        $this->assertEquals("Example 🦆", $hiddenFields['argument1']);
+        $this->assertEquals(":/?#[]@ ", $hiddenFields['nested[argument2]']);
+        $this->assertEquals("!$&'\"()*+,;=", $hiddenFields['nested[argument3]']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateHiddenFieldsDoesNotAddQueryArgumentsForMethodPost()
+    {
+        $form = $this->createForm(null, null, null, 'example.com?argument1=Example+%F0%9F%A6%86&nested[argument2]=%3A%2F%3F%23%5B%5D%40%20&nested[argument3]=%21%24%26%27%22%28%29%2A%2B%2C%3B%3D', 'post');
+
+        $hiddenFields = $form->calculateHiddenFields(null);
+
+        $this->assertArrayNotHasKey("argument1", $hiddenFields);
+        $this->assertArrayNotHasKey("nested[argument2]", $hiddenFields);
+        $this->assertArrayNotHasKey("nested[argument3]", $hiddenFields);
     }
 }


### PR DESCRIPTION
If the target the form is submitted to has query arguments those will not be submitted. This change adds those to the hidden fields. This is helpful and mimics a similar behavior of the fluid forms.

See: https://github.com/neos/flow-development-collection/blob/master/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php#L252-L268