### PR TITLE
BUGFIX: Make previous data available to the fusion contexts before subprocesses are evaluated.

### DIFF
--- a/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
+++ b/Classes/Runtime/FusionObjects/MultiStepProcessImplementation.php
@@ -77,6 +77,10 @@ class MultiStepProcessImplementation extends AbstractFusionObject implements Pro
             $this->state = $this->formStateService->unserializeState($internalArguments['__state']);
         }
 
+        // make the current `data` available to the context before sub processes are evaluated
+        // as those may have conditions that rely on previous data
+        $this->runtime->pushContext('data', $this->getData());
+
         // evaluate the subprocesses this has to be done after the state was restored
         // as the current data may affect @if conditions
         $subProcesses = $this->getSubProcesses();
@@ -119,6 +123,9 @@ class MultiStepProcessImplementation extends AbstractFusionObject implements Pro
                 $request->setArgument('__submittedArgumentValidationResults', new Result());
             }
         }
+
+        // restore fusion context to the state before data was pushed
+        $this->runtime->popContext();
     }
 
     /**


### PR DESCRIPTION
Currently the `data` is only pushed to the context before the subprocess is rendered. This change ensures
that the `data` is pushed in the context immediately after it is restored from the form state and stays there for the remaining part of the `handle` method. This ensures it is available while the subprocesses are evaluated the handling of the request is delegated to the submitted step.

That way schemas may use the data for instance to configure fields as required if other fields are set.

```
process = Neos.Fusion.Form:Runtime.MultiStepProcess {
    steps {
        second {
            ...
            schema {
                conditionalField = ${Form.Schema.string()}
                conditionalField.@process.makeRequired = ${value.isRequired()}
                conditionalField.@process.makeRequired.@if.hasOtherValue = ${data.otherValue}
            }
        }
    }
}
```

This even allows to make whole steps conditional

```
process = Neos.Fusion.Form:Runtime.MultiStepProcess {
    steps {
        address {
            ...
        }
        visa {
            @if.fromForeignGalaxy = ${data.galaxy != 'milkyway'}
            ...
        }
    }
}
```