### PR TITLE
DOCS: add Neos.Fusion.Form:Date to docs

### DIFF
--- a/Documentation/FusionReference.rst
+++ b/Documentation/FusionReference.rst
@@ -95,6 +95,11 @@ Neos.Fusion.Form:Submit
 
 Extends `Neos.Fusion.Form:Input`_ and uses the default type `submit`.
 
+Neos.Fusion.Form:Date
+----------------------
+
+Extends `Neos.Fusion.Form:Input`_ and uses the default type `date` and converts the date to string.
+
 Neos.Fusion.Form:Checkbox
 -------------------------
 


### PR DESCRIPTION
The Date input is missing in the fusion reference