### PR TITLE
Bugfix: Adjust to api changes in Neos 9.0

### DIFF
--- a/Classes/Domain/AbstractFormObject.php
+++ b/Classes/Domain/AbstractFormObject.php
@@ -19,7 +19,6 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 
 abstract class AbstractFormObject implements ProtectedContextAwareInterface
 {
-
     /**
      * @var PersistenceManagerInterface
      * @Flow\Inject

--- a/Classes/Domain/Field.php
+++ b/Classes/Domain/Field.php
@@ -25,7 +25,6 @@ use Neos\Utility\ObjectAccess;
  */
 class Field extends AbstractFormObject
 {
-
     /**
      * @var Form|null
      */

--- a/Classes/Domain/Option.php
+++ b/Classes/Domain/Option.php
@@ -22,7 +22,6 @@ namespace Neos\Fusion\Form\Domain;
  */
 class Option extends AbstractFormObject
 {
-
     /**
      * @var mixed
      */

--- a/Classes/FusionObjects/FieldDefinitionImplementation.php
+++ b/Classes/FusionObjects/FieldDefinitionImplementation.php
@@ -19,7 +19,6 @@ use Neos\Fusion\Form\Domain\Field;
 
 class FieldDefinitionImplementation extends AbstractFusionObject
 {
-
     /**
      * @return Form|null
      */

--- a/Classes/FusionObjects/FormDefinitionImplementation.php
+++ b/Classes/FusionObjects/FormDefinitionImplementation.php
@@ -20,7 +20,6 @@ use Neos\Error\Messages\Result;
 
 class FormDefinitionImplementation extends AbstractFusionObject
 {
-
     /**
      * @return ActionRequest|null
      */

--- a/Classes/Runtime/Action/EmailAction.php
+++ b/Classes/Runtime/Action/EmailAction.php
@@ -22,7 +22,6 @@ use Psr\Http\Message\UploadedFileInterface;
 
 class EmailAction extends AbstractAction
 {
-
     /**
      * @return ActionResponse|null
      * @throws ActionException

--- a/Classes/Runtime/Domain/ActionResolver.php
+++ b/Classes/Runtime/Domain/ActionResolver.php
@@ -21,7 +21,6 @@ use Neos\Fusion\Form\Runtime\Domain\Exception\NoSuchActionException;
 
 class ActionResolver
 {
-
     /**
      * @Flow\Inject
      * @var ObjectManagerInterface

--- a/Classes/Runtime/FusionObjects/ActionImplementation.php
+++ b/Classes/Runtime/FusionObjects/ActionImplementation.php
@@ -22,7 +22,6 @@ use Neos\Fusion\FusionObjects\AbstractFusionObject;
 
 class ActionImplementation extends AbstractFusionObject implements ActionInterface
 {
-
     /**
      * @var ActionResolver
      * @Flow\Inject

--- a/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
+++ b/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
@@ -24,7 +24,6 @@ use Neos\Fusion\Form\Runtime\Domain\FormRequestFactory;
 
 class RuntimeFormImplementation extends AbstractFusionObject
 {
-
     /**
      * @var FormRequestFactory
      * @Flow\Inject

--- a/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
+++ b/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
@@ -100,7 +100,9 @@ class RuntimeFormImplementation extends AbstractFusionObject
         $process = $this->getProcess();
 
         $formRequest = $this->formRequestFactory->createFormRequest($this->getCurrentActionRequest(), $namespace);
-        $this->runtime->pushContext('request', $formRequest);
+        $context = $this->runtime->getCurrentContext();
+        $context['request'] = $formRequest;
+        $this->runtime->pushContextArray($context);
         $process->handle($formRequest, $data);
         if ($process->isFinished() === false) {
             $result = $this->renderForm($process, $formRequest, $this->getAttributes());

--- a/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
+++ b/Classes/Runtime/FusionObjects/RuntimeFormImplementation.php
@@ -100,6 +100,12 @@ class RuntimeFormImplementation extends AbstractFusionObject
 
         $formRequest = $this->formRequestFactory->createFormRequest($this->getCurrentActionRequest(), $namespace);
         $context = $this->runtime->getCurrentContext();
+        /**
+          * The internal method "pushContextArray" allows some creative use,
+          * as that we can override the "request" context.
+          * This is not permitted via public / official api and probably an unwise idea to do.
+          * {@see \Neos\Fusion\Core\FusionGlobals}
+          */
         $context['request'] = $formRequest;
         $this->runtime->pushContextArray($context);
         $process->handle($formRequest, $data);

--- a/Classes/Runtime/Helper/SchemaDefinition.php
+++ b/Classes/Runtime/Helper/SchemaDefinition.php
@@ -24,7 +24,6 @@ use Neos\Fusion\Form\Runtime\Domain\SchemaInterface;
 
 class SchemaDefinition implements ProtectedContextAwareInterface, SchemaInterface
 {
-
     /**
      * @var PropertyMapper
      * @Flow\Inject


### PR DESCRIPTION
With Neos 9.0 it will not be possible to replace fusion globals like `request` via `pushContext` instead the internal `pushContextArray` has to be used for that. See https://github.com/neos/neos-development-collection/pull/4425

This change adjusts the code to always use `pushContextArray` to set the form subrequest which works in all supported versions of Neos.