### PR TITLE
FEATURE: Add `collectionName` option to `Neos.Fusion.Form:Upload`

### DIFF
--- a/Documentation/FusionReference.rst
+++ b/Documentation/FusionReference.rst
@@ -80,6 +80,12 @@ Neos.Fusion.Form:Upload
 
 Extends `Neos.Fusion.Form:Input`_ and uses the default type `file`.
 
+:collectionName: (string, default = null) name of the resource collection this file should be uploaded to.
+
+.. note:
+  By default the "persistent" collection defined by flow will be used for all uploads unless a `collectionName` is set.
+  It is strongly recommended to changes that to a different collection that is not publicly available!
+
 Neos.Fusion.Form:Password
 -------------------------
 

--- a/Resources/Private/Fusion/Prototypes/Upload.fusion
+++ b/Resources/Private/Fusion/Prototypes/Upload.fusion
@@ -2,11 +2,18 @@ prototype(Neos.Fusion.Form:Upload)  < prototype(Neos.Fusion.Form:Component.Field
 
     attributes.type = "file"
 
+    collectionName = null
+
     renderer = afx`
         <input
             @if.has={Type.instance(field.getCurrentValue(), 'Neos\Flow\ResourceManagement\PersistentResource')}
             type="hidden" name={field.getName() + '[originallySubmittedResource][__identity]'}
             value={field.getCurrentValueStringified()}
+        />
+        <input
+            @if.has={props.collectionName}
+            type="hidden" name={field.getName() + '[__collectionName]'}
+            value={props.collectionName}
         />
         <input
             name={field.getName()}


### PR DESCRIPTION
The new option allows to specify a collection other than `persistent` where the uploaded file will be stored. This is analog to a feature of the UploadViewHelper that until now had no equivalent in fusion form.