### PR TITLE
added an additional condition for arrays

### DIFF
--- a/Classes/Domain/AbstractFormObject.php
+++ b/Classes/Domain/AbstractFormObject.php
@@ -39,6 +39,9 @@ abstract class AbstractFormObject implements ProtectedContextAwareInterface
                 return $identifier;
             }
         }
+        if(is_array($value)) {
+            $value = json_encode($value);
+        }
         return (string)$value;
     }
 

--- a/Classes/Domain/AbstractFormObject.php
+++ b/Classes/Domain/AbstractFormObject.php
@@ -39,7 +39,7 @@ abstract class AbstractFormObject implements ProtectedContextAwareInterface
                 return $identifier;
             }
         }
-        if(is_array($value)) {
+        if (is_array($value)) {
             $value = json_encode($value);
         }
         return (string)$value;


### PR DESCRIPTION
I use field[0] and field[1] in a Fusion Form in conjunction with a validator. Without this condition, I end up in
`Warning: Array to string conversion in /data/neos/Packages/Application/Neos.Fusion.Form/Classes/Domain/AbstractFormObject.php line 42`