### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/Classes/Domain/AbstractFormObject.php
+++ b/Classes/Domain/AbstractFormObject.php
@@ -51,7 +51,7 @@ abstract class AbstractFormObject implements ProtectedContextAwareInterface
      * @param mixed[] $value
      * @return string[]
      */
-    protected function stringifyMultivalue(iterable $value = null): array
+    protected function stringifyMultivalue(?iterable $value = null): array
     {
         if (is_iterable($value)) {
             $result = [];
@@ -71,7 +71,7 @@ abstract class AbstractFormObject implements ProtectedContextAwareInterface
      * @param string|null $namespace
      * @return string
      */
-    protected function prefixFieldName(string $fieldName, string $namespace = null): string
+    protected function prefixFieldName(string $fieldName, ?string $namespace = null): string
     {
         if (!$namespace) {
             return $fieldName;

--- a/Classes/Domain/Field.php
+++ b/Classes/Domain/Field.php
@@ -62,7 +62,7 @@ class Field extends AbstractFormObject
      * @param mixed|null $targetValue The target value for the field, only used for check, radio and button
      * @param bool $multiple Shall the field contain multiple or a single value, used for checkboxes and selects
      */
-    public function __construct(Form $form = null, string $name = null, $targetValue = null, $multiple = false)
+    public function __construct(?Form $form = null, ?string $name = null, $targetValue = null, $multiple = false)
     {
         $this->form = $form;
         $this->name = $name ?? '';

--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -102,7 +102,7 @@ class Form extends AbstractFormObject
      * @param bool $enableReferrer
      * @param bool $enableTrustedProperties
      */
-    public function __construct(ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $enableReferrer = true, bool $enableTrustedProperties = true)
+    public function __construct(?ActionRequest $request = null, $data = null, ?string $namespace = null, ?string $target = null, ?string $method = "get", ?string $encoding = null, bool $enableReferrer = true, bool $enableTrustedProperties = true)
     {
         $this->request = $request;
         $this->data = $data;
@@ -208,10 +208,10 @@ class Form extends AbstractFormObject
      * prototypes and to calculate hidden identify and trusted properties for those
      * fields aswell.
      *
-     * @param string $content The form html body, usually renderd via afx
+     * @param string|null $content The form html body, usually renderd via afx
      * @return string[] hiddenFields as key value pairs
      */
-    public function calculateHiddenFields(string $content = null): array
+    public function calculateHiddenFields(?string $content = null): array
     {
         $hiddenFields = [];
 

--- a/Classes/Runtime/Helper/ArrayOfSchemaDefinition.php
+++ b/Classes/Runtime/Helper/ArrayOfSchemaDefinition.php
@@ -29,7 +29,7 @@ class ArrayOfSchemaDefinition extends SchemaDefinition
      * @param mixed[] $validators
      * @param mixed[] $validatorOptions
      */
-    public function __construct(SchemaInterface $itemSchema = null, array $validators = [], array $validatorOptions = [])
+    public function __construct(?SchemaInterface $itemSchema = null, array $validators = [], array $validatorOptions = [])
     {
         parent::__construct('array', $validators, $validatorOptions);
         $this->itemSchema = $itemSchema;


### PR DESCRIPTION
...by removing implicit nullability

Note: This package declares compatibility with PHP 7.2, nullable parameters are supported from 7.1 on and are thus safe.