### PR TITLE
TASK: Remove check if symfonymailer package is installed

### DIFF
--- a/Classes/Runtime/Action/EmailAction.php
+++ b/Classes/Runtime/Action/EmailAction.php
@@ -36,10 +36,6 @@ class EmailAction extends AbstractAction
      */
     public function perform(): ?ActionResponse
     {
-        if (!class_exists(MailerService::class)) {
-            throw new ActionException('The "neos/symfonymailer" doesn\'t seem to be installed, but is required for the EmailAction to work!', 1503392532);
-        }
-
         $subject = $this->options['subject'] ?? null;
         $text = $this->options['text'] ?? null;
         $html = $this->options['html'] ?? null;


### PR DESCRIPTION
This is not needed anymore, as the neos/symfonymailer package is now a dependency and always installed.
See #95 