### PR TITLE
TASK: Make neos/symfonymailer an optional dependency

### DIFF
--- a/Classes/Runtime/Action/EmailAction.php
+++ b/Classes/Runtime/Action/EmailAction.php
@@ -162,6 +162,8 @@ class EmailAction extends AbstractAction
 
     private function getMailerService(): MailerService
     {
-        return $this->objectManager->get(MailerService::class);
+        /** @var MailerService $mailerService */
+        $mailerService = $this->objectManager->get(MailerService::class);
+        return $mailerService;
     }
 }

--- a/Classes/Runtime/Action/EmailAction.php
+++ b/Classes/Runtime/Action/EmailAction.php
@@ -15,6 +15,7 @@ namespace Neos\Fusion\Form\Runtime\Action;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionResponse;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Fusion\Form\Runtime\Domain\Exception\ActionException;
 use Neos\SymfonyMailer\Service\MailerService;
@@ -28,7 +29,7 @@ use Symfony\Component\Mime\Part\File;
 class EmailAction extends AbstractAction
 {
     #[Flow\Inject]
-    protected MailerService $mailerService;
+    protected ObjectManagerInterface $objectManager;
 
     /**
      * @return ActionResponse|null
@@ -36,6 +37,10 @@ class EmailAction extends AbstractAction
      */
     public function perform(): ?ActionResponse
     {
+        if (!class_exists(MailerService::class)) {
+            throw new ActionException('The "neos/symfonymailer" doesn\'t seem to be installed, but is required for the EmailAction to work!', 1503392532);
+        }
+
         $subject = $this->options['subject'] ?? null;
         $text = $this->options['text'] ?? null;
         $html = $this->options['html'] ?? null;
@@ -119,7 +124,7 @@ class EmailAction extends AbstractAction
             );
             return $response;
         } else {
-            $this->mailerService->getMailer()->send($mail);
+            $this->getMailerService()->getMailer()->send($mail);
         }
 
         return null;
@@ -153,5 +158,10 @@ class EmailAction extends AbstractAction
                 }
             }
         }
+    }
+
+    private function getMailerService(): MailerService
+    {
+        return $this->objectManager->get(MailerService::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         "neos/flow": "^8.0 || ^9.0",
         "neos/fusion": "^8.0 || ^9.0",
         "neos/fusion-afx": "^1.2 || ^7.0 || ^8.0 || ^9.0",
-        "neos/symfonymailer": "^0.1.0",
         "neos/utility-arrays": "*",
         "neos/utility-objecthandling": "*",
         "psr/http-factory": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1 || ^8.0 || ^9.0",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1",
+        "neos/symfonymailer": "^0.1.0"
     },
     "suggest": {
         "neos/symfonymailer": "Required for the Neos.Fusion.Form.Runtime:Email action to work"


### PR DESCRIPTION
To prevent a hard dependency to the neos/symfonymailer package, the MailerService is fetched directly from the object manager. The ProxyBuilding doesn't allow any injection without the class existing.