### PR TITLE
Update recipient and sender names to use empty string instead of null.

### DIFF
--- a/Classes/Runtime/Action/EmailAction.php
+++ b/Classes/Runtime/Action/EmailAction.php
@@ -46,9 +46,9 @@ class EmailAction extends AbstractAction
         $html = $this->options['html'] ?? null;
 
         $recipientAddress = $this->options['recipientAddress'] ?? null;
-        $recipientName = $this->options['recipientName'] ?? null;
+        $recipientName = $this->options['recipientName'] ?? '';
         $senderAddress = $this->options['senderAddress'] ?? null;
-        $senderName = $this->options['senderName'] ?? null;
+        $senderName = $this->options['senderName'] ?? '';
         $replyToAddress = $this->options['replyToAddress'] ?? null;
         $carbonCopyAddress = $this->options['carbonCopyAddress'] ?? null;
         $blindCarbonCopyAddress = $this->options['blindCarbonCopyAddress'] ?? null;


### PR DESCRIPTION
Symfony Mailer expects the name to be a string and not null (see [Address implementation](https://github.com/symfony/mime/blob/8.1/Address.php#L42)). Therefore setting the default of the names to an empty string will prevent us from throwing an exception if they are not set.

Resolves #98 