### PR TITLE
BUGFIX: Replace deprecated `UriBuilder` fusion prototype

### DIFF
--- a/Classes/Domain/Form.php
+++ b/Classes/Domain/Form.php
@@ -166,7 +166,7 @@ class Form extends AbstractFormObject
     }
 
     /**
-     * @return string|null The target uri for the form, usually defined as Neos.Fusion:UriBuilder
+     * @return string|null The target uri for the form, usually defined as Neos.Fusion:ActionUri
      */
     public function getTarget(): ?string
     {

--- a/Documentation/FormBasics.md
+++ b/Documentation/FormBasics.md
@@ -2,7 +2,7 @@
 
 Forms usually are defined by using the `Neos.Fusion.Form:Form` prototype 
 in afx. The `form.target` can be passed as a string but since it is 
-predefined as a `Neos.Fusion:UriBuilder` so in most cases only the target 
+predefined as a `Neos.Fusion:ActionUri` so in most cases only the target 
 `form.target.action` has to be defined. The current `package` and
 `controller` are assumed automatically. By default the `form.method` is `post` but 
 other methods can be used aswell. 

--- a/Documentation/FusionReference.rst
+++ b/Documentation/FusionReference.rst
@@ -21,7 +21,7 @@ In addition the form component will also:
 :form.request: (ActionRequest, defaults to the the current `request`) The data the form is bound to. Can contain objects, scalar and nested values.
 :form.namespace: (string, defaults to `request.getArgumentNamespace()`) The data the form is bound to. Can contain objects, scalar and nested values.
 :form.data: (mixed, defaults to `Neos.Fusion:DataStructure`) The data the form is bound to. Can contain objects, scalar and nested values.
-:form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
+:form.target: (string, default to `Neos.Fusion:ActionUri`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.:attributes: (string), all props are rendered as attributes to the form tag
 :form.enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
@@ -286,7 +286,7 @@ The Form component is a base prototype for rendering forms in afx. The prototype
 :form.request: (ActionRequest, defaults to the the current `request`) The data the form is bound to. Can contain objects, scalar and nested values.
 :form.namespacePrefix: (string, defaults to `request.getArgumentNamespace()`) The data the form is bound to. Can contain objects, scalar and nested values.
 :form.data: (mixed, defaults to `Neos.Fusion:DataStructure`) The data the form is bound to. Can contain objects, scalar and nested values.
-:form.target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
+:form.target: (string, default to `Neos.Fusion:ActionUri`) The target uri the form will be sent to.
 :form.method:  (string, default to `post`) The form method.
 :form.encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
 :form.enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used
@@ -337,7 +337,7 @@ by the `Neos.Fusion.Form:Component.Form`_ prototype.
 :request: (ActionRequest, defaults to the the current `request`) The data the form is bound to. Can contain objects, scalar and nested values.
 :namespacePrefix: (string, defaults to `request.getArgumentNamespace()`) The data the form is bound to. Can contain objects, scalar and nested values.
 :data: (mixed, defaults to `Neos.Fusion:DataStructure`) The data the form is bound to. Can contain objects, scalar and nested values.
-:target: (string, default to `Neos.Fusion:UriBuilder`) The target uri the form will be sent to.
+:target: (string, default to `Neos.Fusion:ActionUri`) The target uri the form will be sent to.
 :method:  (string, default to `post`) The form method.
 :encoding: (string, default to `multipart/form-data` when `form.method` == `post`) The form enctype `multipart/form.data` is required for file-uploads.
 :enableReferrer: (bool, defaults to true) Enable the generation of hidden `__referrer` fields. Can be disabled when the `method` is `get` or no flow validation is used

--- a/Documentation/HelperReference.rst
+++ b/Documentation/HelperReference.rst
@@ -143,7 +143,7 @@ Neos\Fusion\Form\Domain\Form.getSubmittedValues()
 Neos\Fusion\Form\Domain\Form.getTarget()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**Return** (string|null) The target uri for the form, usually defined as Neos.Fusion:UriBuilder
+**Return** (string|null) The target uri for the form, usually defined as Neos.Fusion:ActionUri
 
 Neos\Fusion\Form\Domain\Form.hasErrors()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
+++ b/Resources/Private/Fusion/Prototypes/Definition/Form.fusion
@@ -16,7 +16,7 @@ prototype(Neos.Fusion.Form:Definition.Form) {
     request = ${request}
     namespace = null
     data = Neos.Fusion:DataStructure
-    target = Neos.Fusion:UriBuilder
+    target = Neos.Fusion:ActionUri
     method = 'post'
     encoding = ${(String.toLowerCase(this.method) == 'post') ? 'multipart/form-data' : null}
     enableReferrer = true


### PR DESCRIPTION
Replaces usages of the deprecated `Neos.Fusion:UriBuilder` with `Neos.Fusion:ActionUri`